### PR TITLE
Force Outfits To Use Reptilian Sprites For Asakim

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
@@ -117,7 +117,7 @@
     factions:
     - Syndicate # Making new AI factions is annoying with all the hostilities I have to add, whatever.
   - type: Inventory
-    speciesId: asakim
+    speciesId: reptilian # Aurum - Allows asakim to use different hardsuits and keep their digigrade legs.
     # WWDP-Edit-Start
     femaleDisplacements:
       jumpsuit:
@@ -177,7 +177,7 @@
     #    - HeadTop # WWDP - Because visible horns its cool
     - HeadSide
   - type: Inventory
-    speciesId: asakim
+    speciesId: reptilian # Aurum - Allows asakim to use different hardsuits and keep their digigrade legs.
     femaleDisplacements:
       jumpsuit:
         sizeMaps:


### PR DESCRIPTION
Two lines changed.

The *thorough* solution would be to make a -asakim copy of every -reptilian sprite in the game, then also making a new sprite for every helmet in the game for their weird headshape. Plus also make an asakim sprite for every hardsuit ever.

Yea, no.