### PR TITLE
Syndicate Hardsuits now in Merc RnD

### DIFF
--- a/Resources/Prototypes/_Aurum/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Aurum/Recipes/Lathes/clothing.yml
@@ -10,3 +10,74 @@
    Glass: 500
    Gold: 500
    Diamond: 100
+
+# Hardsuits
+
+- type: latheRecipe
+  id: RogueModsuitRecipe
+  parent: NFBaseEVASuitRecipe
+  completetime: 25
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
+  result: ClothingModsuitRogue
+  materials:
+    Steel: 11000
+    Durathread: 5000
+    Plastic: 3000
+    Plasteel: 4000
+    Silver: 8000
+    Gold: 9500
+
+- type: latheRecipe
+  id: BloodredHardsuitRecipe
+  parent: MonoHardsuitT3TsfRecipe
+  completetime: 20
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
+  result: ClothingOuterHardsuitSyndie
+  materials:
+    Plastic: 5000
+    Steel: 11000
+    Plasteel: 4500
+    Durathread: 3000
+    Silver: 2500
+    Gold: 2500
+
+- type: latheRecipe
+  id: BloodredMedicHardsuitRecipe
+  parent: MonoHardsuitT3TsfRecipe
+  completetime: 20
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
+  result: ClothingOuterHardsuitSyndieMedic
+  materials:
+    Plastic: 3000
+    Steel: 11000
+    Plasteel: 4500
+    Durathread: 3000
+    Silver: 4500
+    Gold: 500
+
+- type: latheRecipe
+  id: ClothingOuterHardsuitSyndicateEliteRecipe
+  parent: NFBaseEVASuitRecipe # Aurum changes start
+  completetime: 25
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
+  result: ClothingOuterHardsuitSyndieElite
+  materials:
+    Steel: 10000
+    Durathread: 9000
+    Plastic: 5000
+    Plasteel: 5000
+    Silver: 9000
+    Gold: 9000
+# Aurum changes end

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
@@ -64,7 +64,7 @@
   parent: ClothingModsuitBase
   id: ClothingModsuitRogue
   name: RX-01 hardsuit control unit
-  description: Core control unit for the RX-01. Survives power spikes, hull breaches, and black market ingenuity. Somehow. Also has built in experimental voidboots.
+  description: Core control unit for the RX-01. Providing magboots, night vision visor, and a hostile enviroment-ready modsuit. # Aurum - Description change etc.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/Back/Modsuits/rogue.rsi

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Hands/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Hands/modsuit.yml
@@ -36,7 +36,7 @@
   parent: ClothingModsuitGauntletsBase
   id: ClothingModsuitGauntletsRogue
   name: RX-01 modsuit gauntlets
-  description: Non-conductive mesh, pressure-sealed seams. Surprisingly legal. Proudly produced in Sector by Ullman Industries.
+  description: Non-conductive mesh, pressure-sealed seams. Provides a strong grip to handle weaponry and tools correctly.
   categories: [HideSpawnMenu]
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
@@ -106,7 +106,7 @@
   parent: [BaseClothingModsuitHelmet, ShowMedicalIcons, ShowSecurityIcons]
   id: ClothingModsuitHelmetRogue
   name: RX-01 modsuit helmet
-  description: Does not currently feature an AI companion- note to self, sell helmet AI as separate purchase.
+  description: A reverse engineered replica of the ancient "Mazu" modsuit, now repurposed for general use by mercenaries and the like. # Aurum - Old description was awful.
   categories: [HideSpawnMenu]
   components:
   - type: Sprite
@@ -119,11 +119,11 @@
         Piercing: 0.9
         Heat: 0.9
         Radiation: 0.95
-  - type: ThermalVision
-    flashDurationMultiplier: 2
-    pulseTime: 2
-    isEquipment: true
-    toggleAction: PulseThermalVision
+  #- type: ThermalVision # Aurum - A single modsuit shouldn't have every single cake.
+  #  flashDurationMultiplier: 2
+  #  pulseTime: 2
+  #  isEquipment: true
+  #  toggleAction: PulseThermalVision
   - type: NightVision
     flashDurationMultiplier: 3.5
     isEquipment: true
@@ -132,6 +132,21 @@
     - type: FlashImmunity
     - type: EyeProtection
       protectionTime: 5
+    - type: BreathMask
+    - type: PressureProtection
+      highPressureMultiplier: 0.3
+      lowPressureMultiplier: 1000
+    - type: TemperatureProtection
+      heatingCoefficient: 0.01
+      coolingCoefficient: 0.01
+    - type: IdentityBlocker
+    - type: IngestionBlocker
+    - type: HideLayerClothing
+      slots:
+      - Hair
+      - Snout
+      - HeadTop
+      - HeadSide
   #THIS WILL BE REPLACED WITH MODULE ↓↓
   - type: ToggleableVisuals
     spriteLayer: light

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -58,7 +58,7 @@
   parent: [ ClothingModsuitChestplateBase, BaseFactionGearPDVT3 ]
   id: ClothingModsuitChestplateRogue
   name: RX-01 modsuit chestplate
-  description: The chestpiece has some warning label on the inside about radiation leaks- and a note next to it 'Remove this label in the final product - Felix
+  description: The chestpiece has some warning label on the inside about radiation leaks. Shouldn't be a problem.
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
@@ -79,7 +79,7 @@
         Slash: 0.45
         Piercing: 0.525
         Heat: 0.5
-        Radiation: 0.2
+        Radiation: 0.8
         Caustic: 0.3
         Poison: 0.8
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
@@ -35,13 +35,39 @@
 
 - type: latheRecipe
   id: ClothingOuterHardsuitJuggernautRogue
-  parent: MonoHardsuitT3TsfRecipe
+  parent: NFBaseEVASuitRecipe # Aurum changes start
+  completetime: 25
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
   result: ClothingOuterHardsuitJuggernaut
+  materials:
+    Steel: 35000
+    Durathread: 8000
+    Plastic: 8000
+    Plasteel: 12000
+    Silver: 5000
+    Gold: 5000
+# Aurum changes end
 
 - type: latheRecipe
   id: ClothingOuterHardsuitSyndieCommanderRogue
-  parent: MonoHardsuitT3TsfRecipe
+  parent: NFBaseEVASuitRecipe # Aurum changes start
+  completetime: 25
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
   result: ClothingOuterHardsuitSyndieCommander
+  materials:
+    Steel: 22000
+    Durathread: 8000
+    Plastic: 6000
+    Plasteel: 8000
+    Silver: 8000
+    Gold: 8000
+# Aurum changes end
 
 # misc
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
@@ -15,7 +15,11 @@
   - ClothingOuterHardsuitSyndieEliteRogue
   - ClothingOuterHardsuitJuggernautRogue
   - ClothingOuterHardsuitCybersunStealthRogue
-# - ClothingOuterHardsuitSyndieCommanderRogue
+  - ClothingOuterHardsuitSyndieCommanderRogue # Aurum - Uncommented it.
+  - RogueModsuitRecipe # Aurum
+  - BloodredHardsuitRecipe # Aurum
+  - BloodredMedicHardsuitRecipe # Aurum
+  - ClothingOuterHardsuitSyndicateEliteRecipe # Aurum
 
 - type: latheRecipePack
   id: MonoRogueWeaponsDynamicMelee

--- a/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
@@ -5,7 +5,7 @@
   entityIcon: ClothingOuterHardsuitPirateScaf
   discipline: RogueEquipment
   tier: 1
-  cost: 20000
+  cost: 18000 # Aurum 20000 to 18000
   recipeUnlocks:
   - ClothingOuterHardsuitPirateScafRogue
   - ClothingOuterVestWebRogue
@@ -16,12 +16,13 @@
 - type: technology
   id: RogueAdvancedEquipment
   name: research-technology-rogue-advanced-equipment
-  entityIcon: ClothingOuterHardsuitPDVMedic
+  entityIcon: ClothingOuterHardsuitSyndie # Aurum - From the ashen medic suit to the bloodred.
   discipline: RogueEquipment
   tier: 2
-  cost: 35000
+  cost: 25000 # Aurum 35000 to 25000
   recipeUnlocks:
-  - ClothingOuterHardsuitPDVMedic
+#  - ClothingOuterHardsuitPDVMedic # Aurum - Moving the stupidly strong T2 to later T2
+  - BloodredHardsuitRecipe # Aurum - Add bloodreds to rogues again ig.
   - ClothingShoesBootsMagSyndieRogue
   - ClothingMaskGasSyndicateRogue
   - MechIFFPDV
@@ -36,9 +37,12 @@
   entityIcon: ClothingOuterHardsuitAshen
   discipline: RogueEquipment
   tier: 2
-  cost: 50000
+  cost: 32000 # Aurum 50000 to 32000
   recipeUnlocks:
   - ClothingOuterHardsuitSyndieRogue
+  - BloodredMedicHardsuitRecipe # Aurum addon
+  - RogueModsuitRecipe # Aurum - Bring the modsuit back to research
+  - ClothingOuterHardsuitPDVMedic # Aurum - Bring the strong T2 to later T2.
   - ClothingOuterHardsuitSyndieEliteRogue
   technologyPrerequisites:
   - RogueAdvancedEquipment
@@ -50,11 +54,13 @@
   name: research-technology-rogue-super-armor
   entityIcon: ClothingOuterHardsuitCybersunStealth
   discipline: RogueEquipment
-  tier: 2
-  cost: 20000
+  tier: 3 # Aurum, tier 2 -> 3
+  cost: 55000 # Aurum 20000 to 55000, these are the LAST tier, they should be treated as such.
   recipeUnlocks:
   - ClothingOuterHardsuitCybersunStealthRogue
   - ClothingOuterHardsuitJuggernautRogue
+  - ClothingOuterHardsuitSyndieCommanderRogue
+  - ClothingOuterHardsuitSyndicateEliteRecipe # Aurum
   technologyPrerequisites:
   - RogueSyndicateTacsuits
   position: 21, 12


### PR DESCRIPTION
## About the PR
Check media

## Why / Balance
In our lore Syndicate hardsuits are now public knowledge and pretty much the average suit for pirates.
The material costs are because we're looking to make materials more meaningful, and I noticed a bunch of mono hardsuits just, use way too little mats lmao.

## Media
<img width="344" height="641" alt="RogueSyndicate1" src="https://github.com/user-attachments/assets/95dec4c8-b311-4dd1-87ac-a848e8deb95f" />
<img width="363" height="674" alt="RogueSyndicate2" src="https://github.com/user-attachments/assets/055b2650-4d2e-4288-97fb-1f26afaef163" />
<img width="344" height="630" alt="RogueSyndicate3" src="https://github.com/user-attachments/assets/c8f52cec-698c-474b-b3d3-37ab97df9517" />
<img width="682" height="196" alt="nz09tn3" src="https://github.com/user-attachments/assets/d436498e-518f-4ad5-8b19-a4a8da36297c" />
<img width="558" height="215" alt="m660jqk" src="https://github.com/user-attachments/assets/2cebc766-f4d9-4dfe-bdf1-f72b86a1a07c" />
<img width="659" height="263" alt="x1vdt2b" src="https://github.com/user-attachments/assets/c94e567a-3f6c-49b4-9805-84064e8a1176" />
<img width="609" height="222" alt="k049pj6" src="https://github.com/user-attachments/assets/de73e04c-657f-49a2-ae39-7b66866b0163" />
<img width="676" height="265" alt="hrjb9mp" src="https://github.com/user-attachments/assets/b11e132f-3b8b-4481-a2e9-c1298c08294f" />



## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Go into Dev
Slap the debug disk onto the DEBUG RnD server
research required research stuff
look into pmc lathe
boom

How to test in round / in release
Buy pmc lathe and merc research server
find research disks
research required stuff
done

## Breaking changes
Might be a bit unbalanced but ideally the material cost should be big.

**Changelog**
:cl:
- add: Syndicate Hardsuits have been added to Mercenary Research Servers.
- tweak: The RX-01's obtainment method and description have been changed, along with it's resistances towards radiation.

