### PR TITLE
research changes

### DIFF
--- a/Resources/Locale/en-US/_Aurum/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Aurum/research/technologies.ftl
@@ -1,0 +1,1 @@
+research-technology-advanced-smart-weaponry = Advanced Smart Weaponry

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -270,6 +270,8 @@
     - VisionGoggles
     # WD EDIT END
     - SmartGun # Goobstation
+    # Aurum Packs
+    - SmartLMGs
     # Einstein Engines Packs
     - Translators
   - type: EmagLatheRecipes
@@ -505,6 +507,8 @@
     # Mono - Mechs
     - WeaponMechCombatArsenal
     - SmartGun # Goobstation
+    # Aurum Packs
+    - SmartLMGs
     # Mono start
     - MonoTSFWeaponsDynamicMelee
     - MonoTSFWeaponsDynamicRanged
@@ -521,6 +525,8 @@
     - UniversalMissileAmmo
     - UniversalOrdinance
     - SmartGun #Smart SMG
+    # Aurum Packs
+    - SmartLMGs
     - NFMercenaryTechfabDeprecated
     # Mono end
   - type: MaterialStorage

--- a/Resources/Prototypes/_Aurum/Recipes/Lathes/Packs/weapons.yml
+++ b/Resources/Prototypes/_Aurum/Recipes/Lathes/Packs/weapons.yml
@@ -1,0 +1,4 @@
+﻿- type: latheRecipePack
+  id: SmartLMGs
+  recipes:
+  - WeaponSubMachineSmartLMGRECIPE

--- a/Resources/Prototypes/_Aurum/Recipes/Lathes/smart_weapons.yml
+++ b/Resources/Prototypes/_Aurum/Recipes/Lathes/smart_weapons.yml
@@ -1,0 +1,24 @@
+﻿- type: latheRecipe
+  parent: WeaponSubMachineSmart
+  id: WeaponSubMachineSmartMLA34
+  result: WeaponRifleMla34
+  categories:
+  - SMGs
+  - SmartGuns
+  - Ballistic
+  - Weapons
+
+- type: latheRecipe
+  parent:  WeaponSubMachineSmart
+  id: WeaponSubMachineSmartLMGRECIPE
+  result: WeaponSmartLmg
+  categories:
+  - SMGs
+  - SmartGuns
+  - Ballistic
+  - Weapons
+  materials:
+    Steel: 3500
+    Plasteel: 2000
+    Plastic: 1200
+

--- a/Resources/Prototypes/_Aurum/Research/arsenal.yml
+++ b/Resources/Prototypes/_Aurum/Research/arsenal.yml
@@ -1,0 +1,13 @@
+- type: technology
+  id: AdvancedSmartWeaponry
+  name: research-technology-advanced-smart-weaponry
+  entityIcon: WeaponSmartLmg
+  discipline: Arsenal
+  tier: 3
+  cost: 30000
+  recipeUnlocks:
+  - WeaponSubMachineSmartLMGRECIPE
+  - MagazineSmartLMG
+  technologyPrerequisites:
+  - SmartWeaponry
+  position: 3, 4

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -7,8 +7,9 @@
   cost: 25000
   recipeUnlocks:
   - WeaponSubMachineSmart
+  - WeaponSubMachineSmartMLA34
   - MagazineSmart
-  - MagazineSmartLMG
+#  - MagazineSmartLMG - Aurum change, moved into it's own research.
   - ASMGTUniversallyHostile
   technologyPrerequisites:
   - BasicParts

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
@@ -58,6 +58,8 @@
     - ResearchedExplosives
     - SecurityEquipment
     - SmartGun
+    # Aurum Packs
+    - SmartLMGs
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
@@ -4,7 +4,7 @@
   entityIcon: EnergySword
   discipline: RogueWeaponry
   tier: 3
-  cost: 25000
+  cost: 15000 # Aurum change - Melee's a bit iffy, lowered from 25k to 15k.
   recipeUnlocks:
   - EnergyShieldRogue
   - EnergySwordRogue
@@ -19,7 +19,7 @@
   entityIcon: WeaponVT7
   discipline: RogueWeaponry
   tier: 3
-  cost: 45000
+  cost: 25000 # Aurum - 45k for a single melee, lol no
   recipeUnlocks:
   - HFSwordVT7
   technologyPrerequisites:
@@ -49,7 +49,7 @@
   entityIcon: WeaponRifleM90
   discipline: RogueWeaponry
   tier: 2
-  cost: 55000
+  cost: 25000 # Aurum change - Sudden jump from 15k to 55k in research points for mid-tier weapons isnt ok
   recipeUnlocks:
   - WeaponSubMachineGunWt550Rogue
   - WeaponSubMachineGunAtreidesRogue
@@ -66,7 +66,7 @@
   entityIcon: WeaponSniperHristov
   discipline: RogueWeaponry
   tier: 3
-  cost: 55000
+  cost: 35000 # Aurum change - 55k for a single weapon isnt it.
   recipeUnlocks:
   - WeaponSniperHristovRogue
   - AmmoBox145x114mm

--- a/Resources/Prototypes/_Mono/Research/TSF/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/TSF/faction_tacsuits.yml
@@ -4,7 +4,7 @@
   entityIcon: ClothingOuterHardsuitM82c
   discipline: TsfmcEquipment
   tier: 1
-  cost: 20000
+  cost: 18000 # Aurum change - Moves them to be on par with the rest of hardsuit research in terms of costs
   recipeUnlocks:
   - ClothingOuterHardsuitM82cTsf
   - ClothingOuterHardsuitM82bTsf
@@ -18,7 +18,7 @@
   entityIcon: ClothingOuterHardsuitM86
   discipline: TsfmcEquipment
   tier: 2
-  cost: 35000
+  cost: 25000 # Aurum change - Moves them to be on par with the rest of hardsuit research in terms of costs
   recipeUnlocks:
   - ClothingOuterHardsuitM86Tsf
   - MechIFFTSF
@@ -33,7 +33,7 @@
   entityIcon: ClothingOuterHardsuitNfsdExperimental
   discipline: TsfmcEquipment
   tier: 3
-  cost: 85000
+  cost: 38000 # Aurum change - Higher than Rogue's because TSF has no T4 tacsuits per say
   recipeUnlocks:
   - ClothingOuterHardsuitM92XTsf
   technologyPrerequisites:

--- a/Resources/Prototypes/_Mono/Research/USSP/ussp_suits.yml
+++ b/Resources/Prototypes/_Mono/Research/USSP/ussp_suits.yml
@@ -4,7 +4,7 @@
   entityIcon: ClothingOuterHardsuitUsspL10
   discipline: UsspEquipment
   tier: 1
-  cost: 25000
+  cost: 18000 # Aurum change - Moves them to be on par with the rest of hardsuit research in terms of costs
   recipeUnlocks:
   - ClothingOuterHardsuitUsspL10USSP
   - ClothingOuterHardsuitUsspL10AUSSP
@@ -18,7 +18,7 @@
   entityIcon: ClothingOuterHardsuitUsspL27
   discipline: UsspEquipment
   tier: 2
-  cost: 45000
+  cost: 25000 # Aurum change - Moves them to be on par with the rest of hardsuit research in terms of costs
   recipeUnlocks:
   - ClothingOuterHardsuitUsspL27USSP
   - ClothingOuterHardsuitUsspM10USSP
@@ -33,7 +33,7 @@
   entityIcon: ClothingModsuitUSSPZastavnik
   discipline: UsspEquipment
   tier: 3
-  cost: 85000
+  cost: 38000 # Aurum change - Moves them to be on par with the rest of hardsuit research in terms of costs
   recipeUnlocks:
   - ClothingModsuitUSSPVaryagUSSP
   - ClothingModsuitUSSPZastavnikUSSP

--- a/Resources/Prototypes/_Mono/Research/USSP/ussp_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/USSP/ussp_weapons.yml
@@ -32,12 +32,12 @@
   entityIcon: WeaponRifleAK410
   discipline: UsspWeapons
   tier: 2
-  cost: 25000
+  cost: 15000 # Aurum - Single weapon that could have probably been packed into the medium package, lowered from 25k to 15k
   recipeUnlocks:
   - WeaponRifleAK410USSP
   technologyPrerequisites:
   - UsspMediumGuns
-  position: 16, 8
+  position: 17, 7
 
 - type: technology
   id: UsspAdvancedGuns
@@ -45,7 +45,7 @@
   entityIcon: WeaponDP29
   discipline: UsspWeapons
   tier: 3
-  cost: 80000
+  cost: 38000 # Aurum - Lowered from 80k to 38k
   recipeUnlocks:
   - WeaponDP29USSP
   - MagazineDP29

--- a/Resources/Prototypes/_Mono/Research/Universal/economy.yml
+++ b/Resources/Prototypes/_Mono/Research/Universal/economy.yml
@@ -5,7 +5,7 @@
   entityIcon: UraniumProcessingIcon
   discipline: FactionUniversal
   tier: 1
-  cost: 20000
+  cost: 10000 # Aurum change - This is essentially random, and can be a material loss half the time
   recipeUnlocks:
   - CentrifugeLatheMiniCircuitboard
   technologyPrerequisites:
@@ -25,7 +25,7 @@
   entityIcon: UraniumEnrichedProcessingIcon
   discipline: FactionUniversal
   tier: 2
-  cost: 30000
+  cost: 15000 # Aurum change
   recipeUnlocks:
   - UraniumCentrifugeReprocessingMini
   - UraniumCentrifugeEnrichedProcessingMini

--- a/Resources/Prototypes/_Mono/Research/Universal/prerequisites.yml
+++ b/Resources/Prototypes/_Mono/Research/Universal/prerequisites.yml
@@ -33,7 +33,7 @@
   entityIcon: SheetPlasteel
   discipline: FactionUniversal
   tier: 2
-  cost: 50000
+  cost: 25000 # Aurum change - Unlocks ammo so that's why I didnt gut it, from 50k to 25k.
   technologyPrerequisites:
   - UniversalMaterialResearchT1
   position: 10, 5
@@ -53,7 +53,7 @@
   entityIcon: SheetPlastitanium
   discipline: FactionUniversal
   tier: 2
-  cost: 100000
+  cost: 35000 # Aurum change - 100k for a research that does nothing and only artificially slows you down in terms of progression, lowered from 100k to 35k
   technologyPrerequisites:
   - UniversalMaterialResearchT2
   position: 10, 10

--- a/Resources/Prototypes/_Mono/Research/experimental.yml
+++ b/Resources/Prototypes/_Mono/Research/experimental.yml
@@ -4,7 +4,7 @@
   entityIcon: MachineCarpCaller
   discipline: Experimental
   tier: 1
-  cost: 35000
+  cost: 5000 # Aurum change, from 35000 back to the original 5000, I genuinely don't see how a machine that functions every 3 mins and attracts ONE mob is worth 35k in research.
   recipeUnlocks:
   - CarpCallerMachineCircuitboard
   - ClothingOuterHardsuitCarp
@@ -22,8 +22,8 @@
   recipeUnlocks:
   - ClothingShoesBootsMagVoid
   technologyPrerequisites:
-  - MagnetsTech
-  position: -2, -2
+  - MagnetsTechAdvanced # Aurum Change - Why is space free movement available nearly roundstart?
+  position: -4, -2
 
 - type: technology
   id: BasicResearch

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -221,6 +221,8 @@
     - SecurityEquipment
     - SmartGun #Smart SMG
     # Mono end
+    # Aurum Packs
+    - SmartLMGs
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFMercenaryTechfabDeprecatedEmag
@@ -273,6 +275,8 @@
     - NFHackedMercenaryTechfabDeprecated
     - DynamicAmmoRecipePack
     - SmartGun # Goobstation
+    # Aurum Packs
+    - SmartLMGs
     # Mono start
     - MonoTSFWeaponsDynamicMelee
     - MonoTSFWeaponsDynamicRanged

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/misc.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/misc.yml
@@ -62,5 +62,6 @@
   id: SmartGun
   recipes:
   - WeaponSubMachineSmart # Goobstation
+  - WeaponSubMachineSmartMLA34 # Aurum Addon
   - MagazineSmart # Goobstation
   - ASMGTUniversallyHostile # Mono


### PR DESCRIPTION
## About the PR
I hate monodevs sense of balancing
Changed A LOOOOOOOOOOOT of the research requirements and similar because my god this shit is BLOATED, HIGH NUMBER, MORE FARMING

## Why / Balance
>Research that unlocks endgame content
>Look inside
>100k for no content

ok bro

## Media
<img width="923" height="576" alt="CarpCallerLarp" src="https://github.com/user-attachments/assets/c2c7ba24-036e-45ff-add2-380cd92fab21" />
<img width="1001" height="547" alt="VoidbootsRebalance" src="https://github.com/user-attachments/assets/8955356f-5f55-4ff1-99c8-dad268a5c97f" />
<img width="418" height="552" alt="SmartWeaponsHeavy" src="https://github.com/user-attachments/assets/ca17655d-7695-40f0-bf4b-72921570eb11" />
<img width="287" height="171" alt="TSF3" src="https://github.com/user-attachments/assets/e276da01-9dc8-4b5a-9906-c97d99b83ddb" />
<img width="249" height="170" alt="TSF2" src="https://github.com/user-attachments/assets/8128250e-2c87-4aef-bf8b-ff63d383d55e" />
<img width="219" height="164" alt="TSF1" src="https://github.com/user-attachments/assets/00a80700-710b-4b3c-846b-14adba58f526" />
<img width="416" height="566" alt="UraniumReprocessing" src="https://github.com/user-attachments/assets/69304921-57ba-4054-9680-117cfad0a903" />
<img width="431" height="542" alt="Uranium centrifuge" src="https://github.com/user-attachments/assets/8feddf0b-2171-4a28-b3ce-72d01bfd2e73" />
<img width="199" height="152" alt="6731rj3" src="https://github.com/user-attachments/assets/b5da1f4c-ddac-4241-88dd-3ca558d12699" />
<img width="418" height="552" alt="18b1jst" src="https://github.com/user-attachments/assets/8439fe7c-d8a5-4c89-b57f-c8efef09fd5a" />


## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
- [X] I didn't curse the mono balance devs with a first grade curse from satan

## How to test
Play the game
some research is no longer bloated, free space movement is no longer near roundstart, life is good

## Breaking changes
Massive conflict bait but we're gonna be a hardfork so ggs

**Changelog**
:cl:
- added: Smart LMGs are no longer exclusive to loadouts and can now be crafted in round!
- tweak: Massive tweaks to Rogu- I mean, PDV- I mean Mercenary research, please check the corresponding PR.
- tweak: Voidboots are once again locked behind Advanced magnetic movement.
- tweak: Research related to uranium research is now cheaper.
- tweak: Hardsuit research costs from TSF / USSP are now more in line with the merc progression (18000 -> 25000 -> X)
- tweak: A large amount of research prices have been changed accordingly to their in-game utility.

