### PR TITLE
QoL ops - Please check the PR

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -7,7 +7,7 @@
   - HideSpawnMenu
   components:
   - type: Item
-    size: Large
+    size: Normal # Aurum - It being massive didn't make sense.
   - type: Sprite
     sprite: Objects/Devices/flatpack.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -624,6 +624,7 @@
     # Einstein Engines Packs
     - Translators # Language
     - TranslatorImplanters # Language
+    - NFPouches # Aurum
   - type: Machine
     board: MedicalTechFabCircuitboard
   - type: StealTarget

--- a/Resources/Prototypes/_Aurum/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/_Aurum/Recipes/Lathes/Packs/clothing.yml
@@ -1,0 +1,8 @@
+﻿- type: latheRecipePack
+  id: LargeChestRigs
+  recipes:
+  - ClothingBeltMilitaryWebbingLarge
+  - ClothingBeltMilitaryWebbingLargeOlive
+  - ClothingBeltMilitaryWebbingLargeGreenRanger
+  - ClothingBeltMilitaryWebbingLargeTan
+  - ClothingBeltMilitaryWebbingLargeBlack

--- a/Resources/Prototypes/_Aurum/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_Aurum/Recipes/Lathes/clothing.yml
@@ -80,4 +80,97 @@
     Plasteel: 5000
     Silver: 9000
     Gold: 9000
-# Aurum changes end
+
+# Trust the process
+- type: latheRecipe
+  id: ClothingOuterHardsuitMaidnautJuggernaut
+  parent: NFBaseEVASuitRecipe # Aurum changes start
+  completetime: 25
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
+  result: ClothingOuterHardsuitTacticalMaid
+  materials:
+    Steel: 35000
+    Durathread: 15000
+    Plastic: 3000
+    Plasteel: 8000
+    Silver: 2000
+    Gold: 2000
+    Cloth: 24000
+
+
+# Chest Rig Bloat
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingBlack
+  parent: ClothingBeltMilitaryWebbing
+  result: ClothingBeltWebbingsNormalBlack
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingOlive
+  parent: ClothingBeltMilitaryWebbing
+  result: ClothingBeltWebbingsNormalOlive
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingRangerGreen
+  parent: ClothingBeltMilitaryWebbing
+  result: ClothingBeltWebbingsNormalRangerGreen
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingTan
+  parent: ClothingBeltMilitaryWebbing
+  result: ClothingBeltWebbingsNormalTan
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingLarge
+  parent: NFBaseBeltRecipe
+  result: ClothingBeltWebbingsBigBase
+  materials:
+    Cloth: 800
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingLargeOlive
+  parent: NFBaseBeltRecipe
+  result: ClothingBeltWebbingsBigOlive
+  materials:
+    Cloth: 800
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingLargeGreenRanger
+  parent: NFBaseBeltRecipe
+  result: ClothingBeltWebbingsBigRangerGreen
+  materials:
+    Cloth: 800
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingLargeTan
+  parent: NFBaseBeltRecipe
+  result: ClothingBeltWebbingsBigTan
+  materials:
+    Cloth: 800
+
+- type: latheRecipe
+  id: ClothingBeltMilitaryWebbingLargeBlack
+  parent: NFBaseBeltRecipe
+  result: ClothingBeltWebbingsBigBlack
+  materials:
+    Cloth: 800
+
+# Footwear - Boots, Magboots, etc.,
+
+- type: latheRecipe
+  id: ClothingShoesBootsAdvancedMagbootsTactical
+  categories:
+  - ClothesNF
+  - FactionEquipment
+  result: ClothingShoesBootsMagPDVAdvanced
+  completetime: 8
+  materials:
+    Steel: 2000
+    Silver: 950
+    Plasteel: 450
+    Plastic: 450
+    Plasma: 550
+    Uranium: 50

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/magboots.yml
@@ -50,7 +50,7 @@
   parent: [ ClothingShoesBootsMagAdv, BaseFactionGearPDVT2, BaseJetpack ]
   id: ClothingShoesBootsMagPDVAdvanced
   name: advanced tactical magboots
-  description: Experimental high tech magboots, reverse engineered from the remnants of Pre-fracture technology. These sets are only found in hands of the Dynasty's most valued soldiers.
+  description: Experimental high tech magboots, reverse engineered from the remnants of Pre-war technology. # Aurum - Dynasty lore removal and changing from pre-fracture to pre-war
   components:
   - type: Sprite
     sprite: _Mono/Clothing/Shoes/Boots/magboots-ashen.rsi
@@ -61,7 +61,7 @@
     footstepSoundCollection:
       collection: FootstepHeavySuit
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.8 # Aurum change - Make them actually slightly different.
   - type: GasTank
     outputPressure: 42.6
     air:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
@@ -60,6 +60,7 @@
     - SmartGun
     # Aurum Packs
     - SmartLMGs
+    - LargeChestRigs
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
@@ -14,12 +14,14 @@
   - ClothingOuterHardsuitSyndieRogue
   - ClothingOuterHardsuitSyndieEliteRogue
   - ClothingOuterHardsuitJuggernautRogue
+  - ClothingOuterHardsuitMaidnautJuggernaut # Aurum
   - ClothingOuterHardsuitCybersunStealthRogue
   - ClothingOuterHardsuitSyndieCommanderRogue # Aurum - Uncommented it.
   - RogueModsuitRecipe # Aurum
   - BloodredHardsuitRecipe # Aurum
   - BloodredMedicHardsuitRecipe # Aurum
   - ClothingOuterHardsuitSyndicateEliteRecipe # Aurum
+  - ClothingShoesBootsAdvancedMagbootsTactical # Aurum
 
 - type: latheRecipePack
   id: MonoRogueWeaponsDynamicMelee

--- a/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
@@ -44,6 +44,7 @@
   - RogueModsuitRecipe # Aurum - Bring the modsuit back to research
   - ClothingOuterHardsuitPDVMedic # Aurum - Bring the strong T2 to later T2.
   - ClothingOuterHardsuitSyndieEliteRogue
+  - ClothingShoesBootsAdvancedMagbootsTactical # Aurum
   technologyPrerequisites:
   - RogueAdvancedEquipment
   - UniversalMaterialResearchT3
@@ -59,6 +60,7 @@
   recipeUnlocks:
   - ClothingOuterHardsuitCybersunStealthRogue
   - ClothingOuterHardsuitJuggernautRogue
+  - ClothingOuterHardsuitMaidnautJuggernaut # Aurum
   - ClothingOuterHardsuitSyndieCommanderRogue
   - ClothingOuterHardsuitSyndicateEliteRecipe # Aurum
   technologyPrerequisites:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -95,7 +95,7 @@
 
 #Tactical hardsuit Helmet
 - type: entity
-  parent: NFClothingHeadHardsuitWithLightBase
+  parent: [NFClothingHeadHardsuitWithLightBase, ClothingHeadHelmetHardsuitCybersun]
   id: ClothingHeadHelmetHardsuitTacticalMaid
   name: tactical maid hardsuit helmet
   description: Welded stainless steel alloy covered in multiple layers of anticorrosive materials, perfect for cleaning.
@@ -106,15 +106,15 @@
     sprite: _NF/Clothing/Head/Hardsuits/tactical_hardsuit.rsi
   - type: Clothing
     sprite: _NF/Clothing/Head/Hardsuits/tactical_hardsuit.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 0.525
-    lowPressureMultiplier: 1000
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+#  - type: PressureProtection
+#    highPressureMultiplier: 0.525
+#    lowPressureMultiplier: 1000
+#  - type: Armor
+#    modifiers:
+#      coefficients:
+#        Blunt: 0.8
+#        Slash: 0.8
+#        Piercing: 0.8
 
 - type: entity
   parent: NFClothingHeadHardsuitWithLightBase

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -184,7 +184,7 @@
 # Tactical Maid Hardsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterHardsuitJuggernaut # Aurum Change from base hardsuit to Juggernaut
   id: ClothingOuterHardsuitTacticalMaid
   name: tactical maid hardsuit
   description: Layers of stain resistant alloys built into a single suit. It even comes with a reinforced apron!
@@ -193,21 +193,21 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/tactical_hardsuit.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/tactical_hardsuit.rsi
-  - type: Armor # Remains perfectly clean of stains
-    modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Caustic: 0.05
-  - type: ExplosionResistance
-    damageCoefficient: 0.8
-  - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier # So many layers of stain protection makes it very heavy
-    walkModifier: 0.75
-    sprintModifier: 0.75
+#  - type: Armor # Remains perfectly clean of stains
+#    modifiers:
+#      coefficients:
+#        Blunt: 0.9
+#        Slash: 0.9
+#        Piercing: 0.9
+#        Caustic: 0.05
+#  - type: ExplosionResistance
+#    damageCoefficient: 0.8
+#  - type: PressureProtection
+#    highPressureMultiplier: 0.5
+#    lowPressureMultiplier: 1000
+#  - type: ClothingSpeedModifier # So many layers of stain protection makes it very heavy
+#    walkModifier: 0.75
+#    sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: FootstepModifier
     footstepSoundCollection:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -44,6 +44,7 @@
     - NFServiceTechfabDeprecatedStatic
     dynamicPacks:
     - NFServiceTechfabDeprecated
+    - NFPouches # Aurum
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFServiceTechfabDeprecatedEmagStatic
@@ -84,6 +85,7 @@
     dynamicPacks:
     - NFEngineeringTechfabDeprecated
     - RCD # Mono
+    - NFPouches # Aurum
   - type: PirateBountyItem # Mono
     id: Techfab
 
@@ -116,6 +118,7 @@
     - NFSalvageTechfabDeprecatedStatic
     dynamicPacks:
     - NFSalvageTechfabDeprecated
+    - NFPouches # Aurum
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFSalvageTechfabDeprecatedEmag
@@ -223,6 +226,8 @@
     # Mono end
     # Aurum Packs
     - SmartLMGs
+    - LargeChestRigs
+    - NFPouches
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFMercenaryTechfabDeprecatedEmag
@@ -277,6 +282,7 @@
     - SmartGun # Goobstation
     # Aurum Packs
     - SmartLMGs
+    - LargeChestRigs
     # Mono start
     - MonoTSFWeaponsDynamicMelee
     - MonoTSFWeaponsDynamicRanged

--- a/Resources/Prototypes/_NF/Mail/mail.yml
+++ b/Resources/Prototypes/_NF/Mail/mail.yml
@@ -1811,7 +1811,7 @@
       - id: ClothingHeadHatTacticalMaidHeadband
       - id: MegaSprayBottle
       - id: ClothingHandsTacticalMaidGloves
-      - id: ClothingOuterHardsuitTacticalMaid
+    #  - id: ClothingOuterHardsuitTacticalMaid - Aurum - Turned this into a proper hardsuit :Godo:
 
 # These could use separate sprites.  That would be a nice touch.
 - type: entity

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -53,6 +53,12 @@
   - ClothingOuterVestWebMercenaryBlack
   - ClothingBeltMercenaryWebbing
   - ClothingBeltMilitaryWebbing
+  # Aurum Start
+  - ClothingBeltMilitaryWebbingBlack # Aurum - In-round choice ops
+  - ClothingBeltMilitaryWebbingOlive # Aurum - In-round choice ops
+  - ClothingBeltMilitaryWebbingRangerGreen # Aurum - In-round choice ops
+  - ClothingBeltMilitaryWebbingTan # Aurum - In-round choice ops
+  # Aurum End
   - ClothingHandsMercenaryGlovesCombat
   - ClothingHandsGlovesCombat
   - ClothingShoesBootsMercenary

--- a/Resources/Prototypes/_NF/Research/arsenal.yml
+++ b/Resources/Prototypes/_NF/Research/arsenal.yml
@@ -22,6 +22,13 @@
   - KatanaNF
   - KukriKnifeNF
   - MacheteNF
+  # Aurum Start
+  - ClothingBeltMilitaryWebbingLarge
+  - ClothingBeltMilitaryWebbingLargeOlive
+  - ClothingBeltMilitaryWebbingLargeGreenRanger
+  - ClothingBeltMilitaryWebbingLargeTan
+  - ClothingBeltMilitaryWebbingLargeBlack
+  # Aurum End
   - ClothingEyesPunkInfoShades
   - ClothingOuterArmorPunkRandomized
   - ClothingOuterArmorPunkRed


### PR DESCRIPTION
## About the PR
Five hundred quality of life features that don't really impact balance too much.
Starting off with the first in-round choice ops.

SOOOOO:
Flatpacks no longer take up 4x8 space, they now take 4x4 like a normal jacket would do.
Any lathes can now produce pouches instead of being limited to the protolathe.
You can now make large chest rigs after taking the bounty honter node in research.
There's a new hardsuit in merc research (totally not PDV's trust me bro).
You can now make advanced tactical magboots, which have received a (probably poor) balance, they allow you to pretty much ignore injury slowdown but make heavy stomping noises.


## Why / Balance
Mono is a extremely PVP focused fork where life doesn't matter and neither does your survival, it's essentially built around respawning over and over without a care in the world, with a lot of items limited to be in loadouts.

Flatpack size makes no sense.
Pouches being limited to the protolathe is dumb.
Large chest rigs being loadout exclusive is another nono.
Stop noticing the maidnaut.

## Media
<img width="396" height="480" alt="s4hnx67" src="https://github.com/user-attachments/assets/fa131fb7-4e9e-4e34-bb3a-8594607b5e38" />
<img width="394" height="228" alt="nr91bzj" src="https://github.com/user-attachments/assets/14afff5c-9924-4185-88e7-b286c03d4b21" />
<img width="802" height="500" alt="f2r5kv9" src="https://github.com/user-attachments/assets/add00bb3-726c-4632-a614-25307ddd35e0" />
<img width="318" height="184" alt="5dsws2k" src="https://github.com/user-attachments/assets/ed99be2e-8e22-43c3-b051-d0ea46706869" />
<img width="490" height="698" alt="d5kfhsj" src="https://github.com/user-attachments/assets/d24df6fc-9ada-41ea-b611-e5ac1fea008b" />


## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.


## How to test

## Breaking changes

**Changelog**
:cl:
- add: Added a new suit to merc research, advanced tactical magboots have been included as well.
- tweak: Pouches are now craftable in most lathes.
- tweak: Large chest rigs are now craftable and locked behind research.
- tweak: Flatpack sizes have been tweaked accordingly to their size.
